### PR TITLE
Server-side code hightlight + multi-char quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This `README` was getting too messy for my taste, so it was time to fire up the 
 - `<sub>` H<sub>2</sub>O
 - `<sup>` x<sup>2</sup>
 - `<ins>` <ins>Inserted</ins>
+- Server-side code hightlight
 
 ## Installation
 You can install `hexo-renderer-markdown-it` by following [these steps in the documentation](https://github.com/celsomiranda/hexo-renderer-markdown-it/wiki/Getting-Started).

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/celsomiranda/hexo-renderer-markdown-it",
   "dependencies": {
     "lodash.assign": "^3.1.0",
-    "markdown-it": "^4.1.1",
+    "markdown-it": "^4.2.2",
     "markdown-it-footnote": "^1.0.0",
     "markdown-it-highlightjs": "^1.1.2",
     "markdown-it-ins": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lodash.assign": "^3.1.0",
     "markdown-it": "^4.1.1",
     "markdown-it-footnote": "^1.0.0",
+    "markdown-it-highlightjs": "^1.1.2",
     "markdown-it-ins": "^1.0.0",
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "^1.0.0",


### PR DESCRIPTION
If merged, this Pull Request must be documented in https://github.com/celsomiranda/hexo-renderer-markdown-it/wiki/Advanced-Configuration#plugins with a piece of information regarding the `markdown-it-highlightjs` : the Hexo default highlight must be set to `enable: false`.

