### PR TITLE
support passing options to markdown-it plugins

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -10,7 +10,11 @@ module.exports = function (data, options) {
 
   if (opt.plugins) {
     parser = opt.plugins.reduce(function (parser, pugs) {
-      return parser.use(require(pugs));
+      if (pugs instanceof Object && pugs.name) {
+        return parser.use(require(pugs.name), pugs.options);
+      } else {
+        return parser.use(require(pugs));
+      }
     }, parser);
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -118,6 +118,33 @@ describe('Hexo Renderer Markdown-it', function () {
     result.should.equal(parsed_plugins);
   });
 
+  it('should render a plugin defined as an object', function () {
+    var parsed_plugins = fs.readFileSync('./test/fixtures/outputs/plugins.html', 'utf8');
+    var ctx = {
+      config: {
+        markdown: {
+          render: {
+            html: false,
+            xhtmlOut: false,
+            breaks: false,
+            langPrefix: 'language-',
+            linkify: false,
+            typographer: false,
+            quotes: '«»“”'
+          },
+          plugins: ['markdown-it-footnote', 'markdown-it-sub', 'markdown-it-sup', 'markdown-it-ins', { name: 'markdown-it-abbr' }]
+        }
+      }
+    };
+    var source = fs.readFileSync('./test/fixtures/markdownit.md', 'utf8');
+    var parse = render.bind(ctx);
+    var result = parse({
+      text: source
+    });
+    ctx = {};
+    result.should.equal(parsed_plugins);
+  });
+
   it('should render anchor-headers if they are defined', function () {
     var anchors_with_permalinks = fs.readFileSync('./test/fixtures/outputs/anchors.html', 'utf8');
     var ctx = {


### PR DESCRIPTION
Small change here -- if the plugins array provides an object instead of a string options can be passed to the plugin.

```yaml
markdown:
  plugins:
    - name: markdown-it-foo
      options:
        param: value
```